### PR TITLE
Allow use of `python setup.py develop`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from cuisine_postgresql import __version__, __maintainer__, __email__
 
 


### PR DESCRIPTION
Use `setuptools.setup` when available, otherwise fall back on `distutils.core.setup`.
