### PR TITLE
Use psql --command instead of parsing stdout

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Atamert Ölçgen
 Matthew R. Scott
+Rob Berry

--- a/cuisine_postgresql.py
+++ b/cuisine_postgresql.py
@@ -38,9 +38,11 @@ def require_fabric(f):
 
 @require_fabric
 def postgresql_database_check(database_name):
-    cmd = 'psql -U postgres -l | grep \'\ {0}  *|\''.format(database_name)
+    cmd = ('psql -tAc "select 1 from pg_database where datname = \'{}\'"'
+           .format(database_name))
     with settings(hide('everything'), warn_only=True):
-        return bool(run_as_postgres(cmd))
+        result = run_as_postgres(cmd)
+    return result == '1'
 
 
 @require_fabric
@@ -85,9 +87,11 @@ def postgresql_database_ensure(database_name,
 
 @require_fabric
 def postgresql_role_check(username):
-    cmd = 'psql -U postgres -c \'\\du\' | grep \'^  *{0}  *|\''.format(username)
+    cmd = ('psql -tAc "select 1 from pg_roles where rolname = \'{}\'"'
+           .format(username))
     with settings(hide('everything'), warn_only=True):
-        return bool(run_as_postgres(cmd))
+        result = run_as_postgres(cmd)
+    return result == '1'
 
 
 @require_fabric
@@ -137,7 +141,7 @@ def run_as_postgres(cmd):
     """
     Run given command as postgres user.
     """
-    # The cd below is needed to aboid the following warning:
+    # The cd below is needed to avoid the following warning:
     #
     #     could not change directory to "/root"
     #

--- a/cuisine_postgresql.py
+++ b/cuisine_postgresql.py
@@ -38,11 +38,9 @@ def require_fabric(f):
 
 @require_fabric
 def postgresql_database_check(database_name):
-    cmd = ('psql -tAc "select 1 from pg_database where datname = \'{}\'"'
-           .format(database_name))
+    cmd = 'psql -tAc "SELECT 1 FROM pg_database WHERE datname = \'{}\'"'.format(database_name)
     with settings(hide('everything'), warn_only=True):
-        result = run_as_postgres(cmd)
-    return result == '1'
+        return run_as_postgres(cmd) == '1'
 
 
 @require_fabric
@@ -87,11 +85,9 @@ def postgresql_database_ensure(database_name,
 
 @require_fabric
 def postgresql_role_check(username):
-    cmd = ('psql -tAc "select 1 from pg_roles where rolname = \'{}\'"'
-           .format(username))
+    cmd = 'psql -tAc "SELECT 1 FROM pg_roles WHERE rolname = \'{}\'"'.format(username)
     with settings(hide('everything'), warn_only=True):
-        result = run_as_postgres(cmd)
-    return result == '1'
+        return run_as_postgres(cmd) == '1'
 
 
 @require_fabric


### PR DESCRIPTION
I think that executing a simple query that returns either '1' or '' is a bit simpler than grep-ing though stdout to determine if a role/database exists. 

I was also having occasional failures with both database_check and user_check whilst testing ec2 deployments. So far using queries has seemed more reliable
